### PR TITLE
service: select hidl protocol at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(GIO_UNIX REQUIRED gio-unix-2.0)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GLIB_UTIL REQUIRED libglibutil)
-pkg_check_modules(GBINDER REQUIRED libgbinder)
+pkg_check_modules(GBINDER REQUIRED libgbinder>=1.1.20)
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)

--- a/service.cpp
+++ b/service.cpp
@@ -438,7 +438,7 @@ int main(int argc, char* argv[])
     app.ret = RET_INVARG;
     app.service = new Sensors();
 
-    app.sm = gbinder_servicemanager_new(device);
+    app.sm = gbinder_servicemanager_new2(device, "hidl", "hidl");
     if (gbinder_servicemanager_wait(app.sm, -1)) {
         app.obj = gbinder_servicemanager_new_local_object
             (app.sm, DEFAULT_IFACE, app_reply, &app);


### PR DESCRIPTION
This allows to select the hidl protocol at runtime via the `gbinder_servicemanager_new2` constructor introduced in libgbinder 1.1.20.