### PR TITLE
sensorfw-core: sync the latest, Qt-less code from repowerd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,6 @@ pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GLIB_UTIL REQUIRED libglibutil)
 pkg_check_modules(GBINDER REQUIRED libgbinder>=1.1.20)
 
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Network REQUIRED)
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -pthread")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -pthread")
 

--- a/SensorFW.cpp
+++ b/SensorFW.cpp
@@ -301,7 +301,7 @@ int SensorFW::DisableSensorEvents(int id) {
     return 0;
 }
 
-int SensorFW::GetAccelerometerEvent(quint64 *ts, int *x, int *y, int *z) {
+int SensorFW::GetAccelerometerEvent(uint64_t *ts, int *x, int *y, int *z) {
     if (!IsSensorEventEnable(ID_ACCELEROMETER))
         return -EPERM;
 
@@ -313,7 +313,7 @@ int SensorFW::GetAccelerometerEvent(quint64 *ts, int *x, int *y, int *z) {
     return 0;
 }
 
-int SensorFW::GetGyroscopeEvent(quint64 *ts, int *x, int *y, int *z) {
+int SensorFW::GetGyroscopeEvent(uint64_t *ts, int *x, int *y, int *z) {
     if (!IsSensorEventEnable(ID_GYROSCOPE))
         return -EPERM;
 
@@ -325,7 +325,7 @@ int SensorFW::GetGyroscopeEvent(quint64 *ts, int *x, int *y, int *z) {
     return 0;
 }
 
-int SensorFW::GetHumidityEvent(quint64 *ts, unsigned *value) {
+int SensorFW::GetHumidityEvent(uint64_t *ts, unsigned *value) {
     if (!IsSensorEventEnable(ID_HUMIDITY))
         return -EPERM;
 
@@ -335,7 +335,7 @@ int SensorFW::GetHumidityEvent(quint64 *ts, unsigned *value) {
     return 0;
 }
 
-int SensorFW::GetLightEvent(quint64 *ts, unsigned *value) {
+int SensorFW::GetLightEvent(uint64_t *ts, unsigned *value) {
     if (!IsSensorEventEnable(ID_LIGHT))
         return -EPERM;
 
@@ -345,7 +345,7 @@ int SensorFW::GetLightEvent(quint64 *ts, unsigned *value) {
     return 0;
 }
 
-int SensorFW::GetMagnetometerEvent(quint64 *ts, int *x, int *y, int *z,
+int SensorFW::GetMagnetometerEvent(uint64_t *ts, int *x, int *y, int *z,
         int *rx, int *ry, int *rz, int *level) {
     if (!IsSensorEventEnable(ID_MAGNETIC_FIELD) &&
         !IsSensorEventEnable(ID_MAGNETIC_FIELD_UNCALIBRATED))
@@ -363,7 +363,7 @@ int SensorFW::GetMagnetometerEvent(quint64 *ts, int *x, int *y, int *z,
     return 0;
 }
 
-int SensorFW::GetOrientationEvent(quint64 *ts, int *degree) {
+int SensorFW::GetOrientationEvent(uint64_t *ts, int *degree) {
     if (!IsSensorEventEnable(ID_DEVICE_ORIENTATION))
         return -EPERM;
 
@@ -387,7 +387,7 @@ int SensorFW::GetOrientationEvent(quint64 *ts, int *degree) {
     return 0;
 }
 
-int SensorFW::GetPressureEvent(quint64 *ts, unsigned *value) {
+int SensorFW::GetPressureEvent(uint64_t *ts, unsigned *value) {
     if (!IsSensorEventEnable(ID_PRESSURE))
         return -EPERM;
 
@@ -397,7 +397,7 @@ int SensorFW::GetPressureEvent(quint64 *ts, unsigned *value) {
     return 0;
 }
 
-int SensorFW::GetProximityEvent(quint64 *ts, unsigned *value, bool *isNear) {
+int SensorFW::GetProximityEvent(uint64_t *ts, unsigned *value, bool *isNear) {
     if (!IsSensorEventEnable(ID_PROXIMITY))
         return -EPERM;
 
@@ -408,7 +408,7 @@ int SensorFW::GetProximityEvent(quint64 *ts, unsigned *value, bool *isNear) {
     return 0;
 }
 
-int SensorFW::GetStepcounterEvent(quint64 *ts, unsigned *value) {
+int SensorFW::GetStepcounterEvent(uint64_t *ts, unsigned *value) {
     if (!IsSensorEventEnable(ID_STEPCOUNTER))
         return -EPERM;
 
@@ -418,7 +418,7 @@ int SensorFW::GetStepcounterEvent(quint64 *ts, unsigned *value) {
     return 0;
 }
 
-int SensorFW::GetTemperatureEvent(quint64 *ts, unsigned *value) {
+int SensorFW::GetTemperatureEvent(uint64_t *ts, unsigned *value) {
     if (!IsSensorEventEnable(ID_TEMPERATURE))
         return -EPERM;
 

--- a/SensorFW.h
+++ b/SensorFW.h
@@ -136,17 +136,17 @@ struct SensorFW {
     int EnableSensorEvents(int id);
     int DisableSensorEvents(int id);
 
-    int GetAccelerometerEvent(quint64 *ts, int *x, int *y, int *z);
-    int GetGyroscopeEvent(quint64 *ts, int *x, int *y, int *z);
-    int GetHumidityEvent(quint64 *ts, unsigned *value);
-    int GetLightEvent(quint64 *ts, unsigned *value);
-    int GetMagnetometerEvent(quint64 *ts, int *x, int *y, int *z,
+    int GetAccelerometerEvent(uint64_t *ts, int *x, int *y, int *z);
+    int GetGyroscopeEvent(uint64_t *ts, int *x, int *y, int *z);
+    int GetHumidityEvent(uint64_t *ts, unsigned *value);
+    int GetLightEvent(uint64_t *ts, unsigned *value);
+    int GetMagnetometerEvent(uint64_t *ts, int *x, int *y, int *z,
         int *rx, int *ry, int *rz, int* level);
-    int GetOrientationEvent(quint64 *ts, int *degree);
-    int GetPressureEvent(quint64 *ts, unsigned *value);
-    int GetProximityEvent(quint64 *ts, unsigned *value, bool *isNear);
-    int GetStepcounterEvent(quint64 *ts, unsigned *value);
-    int GetTemperatureEvent(quint64 *ts, unsigned *value);
+    int GetOrientationEvent(uint64_t *ts, int *degree);
+    int GetPressureEvent(uint64_t *ts, unsigned *value);
+    int GetProximityEvent(uint64_t *ts, unsigned *value, bool *isNear);
+    int GetStepcounterEvent(uint64_t *ts, unsigned *value);
+    int GetTemperatureEvent(uint64_t *ts, unsigned *value);
 
 private:
     SensorData *data;

--- a/Sensors.cpp
+++ b/Sensors.cpp
@@ -95,7 +95,7 @@ static void sensor_event_cb(void *userdata, int id)
     sensors_event_t* events = dev->sensors;
 
     int64_t event_time = -1;
-    quint64 ts;
+    uint64_t ts;
     int x, y, z, rx, ry, rz, tmp;
     unsigned value;
     bool isNear;

--- a/Sensors.h
+++ b/Sensors.h
@@ -36,7 +36,7 @@ constexpr char kWaydroidVendor[] = "The Waydroid Project";
 
 typedef struct SensorDevice {
     SensorFW *mSensorFWDevice;
-    quint64 last_TimeStamp[MAX_NUM_SENSORS];
+    uint64_t last_TimeStamp[MAX_NUM_SENSORS];
     sensors_event_t sensors[MAX_NUM_SENSORS];
     uint32_t pendingSensors;
     int64_t timeStart;

--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,6 @@ Build-Depends: cmake (>= 2.8.10),
                libglibutil-dev,
                libgbinder-dev (>= 1.1.20),
                pkg-config,
-               sensorfw-qt5,
-               qtbase5-dev,
 Maintainer: Erfan Abdi <erfangplus@gmail.com>
 Standards-Version: 3.9.5
 Homepage: https://github.com/WayDroid/waydroid-sensors

--- a/sensorfw-core/CMakeLists.txt
+++ b/sensorfw-core/CMakeLists.txt
@@ -37,9 +37,6 @@ add_library(
 )
 
 target_link_libraries(sensorfw-core PUBLIC
-    Qt5::Core
-    Qt5::Network
-
     ${GIO_LDFLAGS} ${GIO_LIBRARIES}
     ${GIO_UNIX_LDFLAGS} ${GIO_UNIX_LIBRARIES}
     ${GLIB_UTIL_LDFLAGS} ${GLIB_UTIL_LIBRARIES}

--- a/sensorfw-core/include/datatypes/genericdata.h
+++ b/sensorfw-core/include/datatypes/genericdata.h
@@ -27,7 +27,7 @@
 #ifndef GENERICDATA_H
 #define GENERICDATA_H
 
-#include <QMetaType>
+#include <cstdint>
 
 /**
  * A base class for measurement data that contain timestamp.
@@ -41,9 +41,9 @@ public:
      *
      * @param timestamp monotonic time (microsec)
      */
-    TimedData(const quint64& timestamp) : timestamp_(timestamp) {}
+    TimedData(const uint64_t& timestamp) : timestamp_(timestamp) {}
 
-    quint64 timestamp_;  /**< monotonic time (microsec) */
+    uint64_t timestamp_;  /**< monotonic time (microsec) */
 };
 
 /**
@@ -65,12 +65,11 @@ public:
      * @param y Y coordinate.
      * @param z Z coordinate.
      */
-    TimedXyzData(const quint64& timestamp, int x, int y, int z) : TimedData(timestamp), x_(x), y_(y), z_(z) {}
+    TimedXyzData(const uint64_t& timestamp, int x, int y, int z) : TimedData(timestamp), x_(x), y_(y), z_(z) {}
 
     int x_; /**< X value */
     int y_; /**< Y value */
     int z_; /**< Z value */
 };
-Q_DECLARE_METATYPE ( TimedXyzData )
 
 #endif // GENERICDATA_H

--- a/sensorfw-core/include/datatypes/liddata.h
+++ b/sensorfw-core/include/datatypes/liddata.h
@@ -59,9 +59,8 @@ public:
      * @param type Type of lid.
      * @param value Initial value to use
      */
-    LidData(const quint64& timestamp, Type type, unsigned value) :
+    LidData(const uint64_t& timestamp, Type type, unsigned value) :
         TimedData(timestamp), type_(type), value_(value) {}
 };
 
-Q_DECLARE_METATYPE(LidData)
 #endif // LidData_H

--- a/sensorfw-core/include/datatypes/orientationdata.h
+++ b/sensorfw-core/include/datatypes/orientationdata.h
@@ -78,7 +78,7 @@ public:
      * @param rz raw Z coordinate value.
      * @param level Calibration level.
      */
-    CalibratedMagneticFieldData(const quint64& timestamp, int x, int y, int z, int rx, int ry, int rz, int level) :
+    CalibratedMagneticFieldData(const uint64_t& timestamp, int x, int y, int z, int rx, int ry, int rz, int level) :
         TimedData(timestamp),
         x_(x), y_(y), z_(z),
         rx_(rx), ry_(ry), rz_(rz),
@@ -123,7 +123,7 @@ public:
      * @param degrees Angle to north.
      * @param level Magnetometer calibration level.
      */
-    CompassData(const quint64& timestamp, int degrees, int level) :
+    CompassData(const uint64_t& timestamp, int degrees, int level) :
         TimedData(timestamp), degrees_(degrees), rawDegrees_(degrees), correctedDegrees_(0), level_(level) {}
 
     /**
@@ -135,7 +135,7 @@ public:
      * @param correctedDegrees Declination corrected angle to north.
      * @param rawDegrees Not declination corrected angle to north.
      */
-    CompassData(const quint64& timestamp, int degrees, int level, int correctedDegrees, int rawDegrees) :
+    CompassData(const uint64_t& timestamp, int degrees, int level, int correctedDegrees, int rawDegrees) :
         TimedData(timestamp), degrees_(degrees), rawDegrees_(rawDegrees), correctedDegrees_(correctedDegrees), level_(level) {}
 
     int degrees_; /**< Angle to north which may be declination corrected or not. This is the value apps should use */
@@ -162,7 +162,7 @@ public:
      * @param value raw proximity value.
      * @param withinProximity is there an object within proximity.
      */
-    ProximityData(const quint64& timestamp, unsigned int value, bool withinProximity) :
+    ProximityData(const uint64_t& timestamp, unsigned int value, bool withinProximity) :
         TimedUnsigned(timestamp, value), withinProximity_(withinProximity) {}
 
     bool withinProximity_; /**< is an object within proximity or not */

--- a/sensorfw-core/include/datatypes/posedata.h
+++ b/sensorfw-core/include/datatypes/posedata.h
@@ -99,9 +99,8 @@ public:
      * @param timestamp Initial value for timestamp.
      * @param orientation Initial value for orientation.
      */
-    PoseData(const quint64& timestamp, Orientation orientation) : TimedData(timestamp), orientation_(orientation) {}
+    PoseData(const uint64_t& timestamp, Orientation orientation) : TimedData(timestamp), orientation_(orientation) {}
 };
 
-Q_DECLARE_METATYPE(PoseData)
 
 #endif // POSEDATA_H

--- a/sensorfw-core/include/datatypes/tapdata.h
+++ b/sensorfw-core/include/datatypes/tapdata.h
@@ -75,7 +75,7 @@ public:
      * @param direction Direction of tap.
      * @param type Type of tap.
      */
-    TapData(const quint64& timestamp, Direction direction, Type type) :
+    TapData(const uint64_t& timestamp, Direction direction, Type type) :
         TimedData(timestamp), direction_(direction), type_(type) {}
 };
 

--- a/sensorfw-core/include/datatypes/timedunsigned.h
+++ b/sensorfw-core/include/datatypes/timedunsigned.h
@@ -44,11 +44,10 @@ public:
      * @param timestamp timestamp as monotonic time (microsec).
      * @param value value of the measurement.
      */
-    TimedUnsigned(const quint64& timestamp, unsigned value) : TimedData(timestamp), value_(value) {}
+    TimedUnsigned(const uint64_t& timestamp, unsigned value) : TimedData(timestamp), value_(value) {}
 
     unsigned value_; /**< Measurement value. */
 };
 
-Q_DECLARE_METATYPE ( TimedUnsigned )
 
 #endif // TIMED_UNSIGNED_H

--- a/sensorfw-core/include/plugins/sensorfw_common.h
+++ b/sensorfw-core/include/plugins/sensorfw_common.h
@@ -79,11 +79,12 @@ private:
     const char* plugin_interface() const;
     const char* plugin_path() const;
 
-    std::thread read_loop;
+    static gboolean static_data_recieved(GSocket * socket, GIOCondition cond, gpointer user_data);
+
     PluginType m_plugin;
     pid_t m_pid;
     int m_sessionid;
-    bool m_running = false;
+    std::unique_ptr<GSource, decltype(&g_source_unref)> m_gsource;
 };
 }
 }

--- a/sensorfw-core/include/plugins/sensorfw_common.h
+++ b/sensorfw-core/include/plugins/sensorfw_common.h
@@ -82,6 +82,7 @@ private:
     static gboolean static_data_recieved(GSocket * socket, GIOCondition cond, gpointer user_data);
 
     PluginType m_plugin;
+    std::unique_ptr<char, decltype(&free)> m_pluginPath;
     pid_t m_pid;
     int m_sessionid;
     std::unique_ptr<GSource, decltype(&g_source_unref)> m_gsource;

--- a/sensorfw-core/plugins/sensorfw_accelerometer_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_accelerometer_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwAccelerometerSensor::disable_accelerometer_events()
 
 void waydroid::core::SensorfwAccelerometerSensor::data_recived_impl()
 {
-    QVector<AccelerationData> values;
+    std::vector<AccelerationData> values;
     if(!m_socket->read<AccelerationData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_common.cpp
+++ b/sensorfw-core/plugins/sensorfw_common.cpp
@@ -264,6 +264,7 @@ void waydroid::core::Sensorfw::start()
     if (!result)
     {
         GINFO("failed to start SensorfwSensor");
+        stop();
         return;
     }
     g_variant_unref(result);

--- a/sensorfw-core/plugins/sensorfw_common.cpp
+++ b/sensorfw-core/plugins/sensorfw_common.cpp
@@ -38,6 +38,7 @@ waydroid::core::Sensorfw::Sensorfw(
       dbus_event_loop{name},
       m_socket(std::make_shared<SocketReader>()),
       m_plugin(plugin),
+      m_pluginPath(nullptr, free),
       m_pid(getpid()),
       m_gsource(nullptr, g_source_unref)
 {
@@ -45,6 +46,12 @@ waydroid::core::Sensorfw::Sensorfw(
         throw std::runtime_error("Could not create sensorfw backend");
 
     request_sensor();
+
+    char *new_str;
+    if (asprintf(&new_str,"%s/%s", dbus_sensorfw_path, plugin_string()) == -1)
+        GINFO("Unable to create the plugin path.");
+    else
+        m_pluginPath.reset(new_str);
 
     GINFO("Got plugin_string %s", plugin_string());
     GINFO("Got plugin_interface %s", plugin_interface());
@@ -111,11 +118,10 @@ const char* waydroid::core::Sensorfw::plugin_interface() const
 
 const char* waydroid::core::Sensorfw::plugin_path() const
 {
-    char *new_str;
-    if (asprintf(&new_str,"%s/%s", dbus_sensorfw_path, plugin_string()) == -1)
+    if (!m_pluginPath)
         return "";
 
-    return new_str;
+    return m_pluginPath.get();
 }
 
 bool waydroid::core::Sensorfw::load_plugin()

--- a/sensorfw-core/plugins/sensorfw_compass_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_compass_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwCompassSensor::disable_compass_events()
 
 void waydroid::core::SensorfwCompassSensor::data_recived_impl()
 {
-    QVector<CompassData> values;
+    std::vector<CompassData> values;
     if(!m_socket->read<CompassData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_gyroscope_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_gyroscope_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwGyroscopeSensor::disable_gyroscope_events()
 
 void waydroid::core::SensorfwGyroscopeSensor::data_recived_impl()
 {
-    QVector<TimedXyzData> values;
+    std::vector<TimedXyzData> values;
     if(!m_socket->read<TimedXyzData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_humidity_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_humidity_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwHumiditySensor::disable_humidity_events()
 
 void waydroid::core::SensorfwHumiditySensor::data_recived_impl()
 {
-    QVector<TimedUnsigned> values;
+    std::vector<TimedUnsigned> values;
     if(!m_socket->read<TimedUnsigned>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_lid_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_lid_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwLidSensor::disable_lid_events()
 
 void waydroid::core::SensorfwLidSensor::data_recived_impl()
 {
-    QVector<LidData> values;
+    std::vector<LidData> values;
     if(!m_socket->read<LidData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_light_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_light_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwLightSensor::disable_light_events()
 
 void waydroid::core::SensorfwLightSensor::data_recived_impl()
 {
-    QVector<TimedUnsigned> values;
+    std::vector<TimedUnsigned> values;
     if(!m_socket->read<TimedUnsigned>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_magnetometer_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_magnetometer_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwMagnetometerSensor::disable_magnetometer_events()
 
 void waydroid::core::SensorfwMagnetometerSensor::data_recived_impl()
 {
-    QVector<CalibratedMagneticFieldData> values;
+    std::vector<CalibratedMagneticFieldData> values;
     if(!m_socket->read<CalibratedMagneticFieldData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_orientation_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_orientation_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwOrientationSensor::disable_orientation_events()
 
 void waydroid::core::SensorfwOrientationSensor::data_recived_impl()
 {
-    QVector<PoseData> values;
+    std::vector<PoseData> values;
     if(!m_socket->read<PoseData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_pressure_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_pressure_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwPressureSensor::disable_pressure_events()
 
 void waydroid::core::SensorfwPressureSensor::data_recived_impl()
 {
-    QVector<TimedUnsigned> values;
+    std::vector<TimedUnsigned> values;
     if(!m_socket->read<TimedUnsigned>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_proximity_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_proximity_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwProximitySensor::disable_proximity_events()
 
 void waydroid::core::SensorfwProximitySensor::data_recived_impl()
 {
-    QVector<ProximityData> values;
+    std::vector<ProximityData> values;
     if(!m_socket->read<ProximityData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_rotation_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_rotation_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwRotationSensor::disable_rotation_events()
 
 void waydroid::core::SensorfwRotationSensor::data_recived_impl()
 {
-    QVector<TimedXyzData> values;
+    std::vector<TimedXyzData> values;
     if(!m_socket->read<TimedXyzData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_stepcounter_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_stepcounter_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwStepcounterSensor::disable_stepcounter_events()
 
 void waydroid::core::SensorfwStepcounterSensor::data_recived_impl()
 {
-    QVector<TimedUnsigned> values;
+    std::vector<TimedUnsigned> values;
     if(!m_socket->read<TimedUnsigned>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_tap_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_tap_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwTapSensor::disable_tap_events()
 
 void waydroid::core::SensorfwTapSensor::data_recived_impl()
 {
-    QVector<TapData> values;
+    std::vector<TapData> values;
     if(!m_socket->read<TapData>(values))
         return;
 

--- a/sensorfw-core/plugins/sensorfw_temperature_sensor.cpp
+++ b/sensorfw-core/plugins/sensorfw_temperature_sensor.cpp
@@ -63,7 +63,7 @@ void waydroid::core::SensorfwTemperatureSensor::disable_temperature_events()
 
 void waydroid::core::SensorfwTemperatureSensor::data_recived_impl()
 {
-    QVector<TimedUnsigned> values;
+    std::vector<TimedUnsigned> values;
     if(!m_socket->read<TimedUnsigned>(values))
         return;
 

--- a/sensorfw-core/utils/socketreader.cpp
+++ b/sensorfw-core/utils/socketreader.cpp
@@ -186,7 +186,7 @@ void SocketReader::skipAll()
     while (g_pollable_input_stream_is_readable(G_POLLABLE_INPUT_STREAM(istream_))) {
         g_input_stream_skip(
             istream_,
-            /* count */ G_MAXSIZE,
+            /* count */ G_MAXSSIZE,
             /* cancellable */ NULL,
             /* (out) error */ NULL);
     }

--- a/sensorfw-core/utils/socketreader.cpp
+++ b/sensorfw-core/utils/socketreader.cpp
@@ -180,7 +180,7 @@ bool SocketReader::isConnected()
     return (
         socket_ &&
         g_socket_connection_is_connected(socket_) && 
-        g_io_stream_is_closed(G_IO_STREAM(socket_)));
+        !g_io_stream_is_closed(G_IO_STREAM(socket_)));
 }
 
 void SocketReader::skipAll()


### PR DESCRIPTION
I've done a port of the SocketReader code and related code to GLib APIs
in repowerd. This commit brings that code from repowerd commit
32605e47efed ("Merge branch 'focal-proper-backlight-ctrl' into 'main'") to
waydroid-sensors.

This eliminates the need to link to Qt, integrates with the existing
GLib-based EventLoop better, and avoid a memory "leak" from queued
signal emission, as described in [1].

And to remove Qt from the rest of the code, also change the use of
quint64 to a standard uint64_t.

[1] https://gitlab.com/ubports/development/core/packaging/waydroid/-/merge_requests/10#note_1308000201

Fixes: https://github.com/waydroid/waydroid-sensors/issues/3