### PR TITLE
Add systemd system service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+waydroid-sensors.service

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,13 @@ target_include_directories(waydroid-sensord PUBLIC
 )
 
 install(TARGETS waydroid-sensord RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+configure_file(
+	waydroid-sensors.service.in
+	${CMAKE_CURRENT_BINARY_DIR}/waydroid-sensors.service
+)
+
+install(
+	FILES ${CMAKE_CURRENT_BINARY_DIR}/waydroid-sensors.service
+	DESTINATION /usr/lib/systemd/system/
+)

--- a/waydroid-sensors.service.in
+++ b/waydroid-sensors.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Waydroid sensor daemon
+Requires=waydroid-container.service
+PartOf=waydroid-container.service
+After=waydroid-container.service
+
+[Service]
+Type=simple
+ExecStart=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/waydroid-sensord
+RestartSec=1
+TimeoutStartSec=5
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Allows installation of a canonical systemd service that starts and supervises waydroid-sensord.

This file is taken from our downstream services package in postmarketOS and upstreaming it could make future improvements easier and downstream packaging.

I'm not the best at CMake configuration, so please let me know if there is something to nag about.